### PR TITLE
Add iOS 26.4 keyboard changes documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/common-issues/ios-26-keyboard-changes.mdx
+++ b/common-issues/ios-26-keyboard-changes.mdx
@@ -41,6 +41,6 @@ If you haven't already, explore the different [built-in modes](/modes/modes) to 
   </Accordion>
 
   <Accordion title="Can I report this to Apple?">
-    Yes, and we'd encourage it. The more people report the issue, the more likely Apple is to address it. You can file feedback using Apple's [Feedback Assistant](https://feedbackassistant.apple.com/). If you do, consider mentioning the impact on third-party keyboard dictation workflows.
+    Yes, and we'd encourage it. The more people report the issue, the more likely Apple is to address it. You can file feedback using Apple's [Feedback Assistant](https://feedbackassistant.apple.com/). If you do, consider referencing feedback ID **FB22247647**, which tracks the underlying `hostApplicationBundleID` bug affecting third-party keyboards.
   </Accordion>
 </AccordionGroup>

--- a/common-issues/ios-26-keyboard-changes.mdx
+++ b/common-issues/ios-26-keyboard-changes.mdx
@@ -1,0 +1,78 @@
+---
+title: "Adapting to iOS 26"
+description: "How iOS 26 changes affect third-party keyboards like Superwhisper, and what we've done to keep your experience smooth."
+---
+
+<Note>
+This page applies only to Superwhisper on iOS. macOS and Windows are not affected by these changes.
+</Note>
+
+## What Changed
+
+Apple's iOS 26 update introduced changes to how third-party keyboards work. Two behaviors that Superwhisper previously relied on are no longer available:
+
+1. **No automatic app return** — After tapping the Superwhisper keyboard button to start dictation, iOS no longer returns you to your previous app automatically. You now need to swipe back manually.
+
+2. **No per-app detection** — iOS no longer allows third-party keyboards to detect which app is active. This means Superwhisper can no longer automatically switch modes based on the app you're using.
+
+---
+
+## How Superwhisper Adapts
+
+We've introduced two features to keep your workflow smooth despite these platform changes.
+
+### Default Mode
+
+You can now set a preferred default mode that applies everywhere, regardless of which app you're dictating into.
+
+<Steps>
+  <Step title="Open Settings">
+    Launch Superwhisper on your iPhone and tap the gear icon in the top-right corner.
+  </Step>
+  <Step title="Choose Your Default Mode">
+    Select the mode you want to use as your default. This mode will be active across all apps.
+  </Step>
+</Steps>
+
+<Tip>
+If you mostly write messages and emails, try setting your default to **Message** or **Email** mode. You can always switch on the fly when you need something different.
+</Tip>
+
+### Quick Mode Switcher
+
+A mode pill on the keyboard lets you temporarily switch to a different mode for individual conversations or tasks. The override resets automatically after 15 minutes of inactivity, returning you to your default mode.
+
+<Steps>
+  <Step title="Tap the Mode Pill">
+    While the Superwhisper keyboard is active, tap the mode indicator to see your available modes.
+  </Step>
+  <Step title="Select a Temporary Mode">
+    Choose the mode you need. It will stay active until 15 minutes after your last dictation, then revert to your default.
+  </Step>
+</Steps>
+
+---
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Why can't Superwhisper switch modes per app anymore?">
+    Apple removed the ability for third-party keyboards to detect which app is in the foreground. This was an iOS platform change, not something we can work around. The new default mode and quick switcher features are designed to give you equivalent flexibility.
+  </Accordion>
+
+  <Accordion title="Why do I have to swipe back to my app after starting dictation?">
+    iOS 26 no longer allows third-party keyboards to programmatically return you to the previous app. You'll need to swipe back manually after tapping the Superwhisper button.
+  </Accordion>
+
+  <Accordion title="Do these changes affect macOS or Windows?">
+    No. These are iOS-specific platform changes. The macOS and Windows versions of Superwhisper are unaffected, and features like auto-activation rules continue to work as expected.
+  </Accordion>
+
+  <Accordion title="What languages are supported for the new features?">
+    The default mode and quick mode switcher require English or British English language settings. Support for additional languages is being rolled out gradually.
+  </Accordion>
+
+  <Accordion title="I'm seeing unexpected behavior beyond what's described here">
+    If you're experiencing issues not covered above, please contact <a href="mailto:support@superwhisper.com">support@superwhisper.com</a> with your iPhone model and iOS version.
+  </Accordion>
+</AccordionGroup>

--- a/common-issues/ios-26-keyboard-changes.mdx
+++ b/common-issues/ios-26-keyboard-changes.mdx
@@ -19,37 +19,11 @@ Apple's iOS 26.4 update introduced changes to how third-party keyboards work. Tw
 
 ## How Superwhisper Adapts
 
-We've introduced two features to keep your workflow smooth despite these platform changes.
-
-### Default Mode
-
-You can now set a preferred default mode that applies everywhere, regardless of which app you're dictating into.
-
-<Steps>
-  <Step title="Open Settings">
-    Launch Superwhisper on your iPhone and tap the gear icon in the top-right corner.
-  </Step>
-  <Step title="Choose Your Default Mode">
-    Select the mode you want to use as your default. This mode will be active across all apps.
-  </Step>
-</Steps>
+Since per-app detection is no longer available, you'll need to manually switch between modes when moving between tasks. Superwhisper's existing [modes](/modes/modes) — like **Message**, **Email**, **Note**, and any custom modes you've created — all continue to work as before. The only difference is that switching is now always manual.
 
 <Tip>
-If you mostly write messages and emails, try setting your default to **Message** or **Email** mode. You can always switch on the fly when you need something different.
+If you haven't already, explore the different [built-in modes](/modes/modes) to find the ones that fit your most common tasks. You can also [create custom modes](/modes/custom) tailored to specific workflows.
 </Tip>
-
-### Quick Mode Switcher
-
-A mode pill on the keyboard lets you temporarily switch to a different mode for individual conversations or tasks. The override resets automatically after 15 minutes of inactivity, returning you to your default mode.
-
-<Steps>
-  <Step title="Tap the Mode Pill">
-    While the Superwhisper keyboard is active, tap the mode indicator to see your available modes.
-  </Step>
-  <Step title="Select a Temporary Mode">
-    Choose the mode you need. It will stay active until 15 minutes after your last dictation, then revert to your default.
-  </Step>
-</Steps>
 
 ---
 
@@ -57,7 +31,7 @@ A mode pill on the keyboard lets you temporarily switch to a different mode for 
 
 <AccordionGroup>
   <Accordion title="Why can't Superwhisper switch modes per app anymore?">
-    Apple removed the ability for third-party keyboards to detect which app is in the foreground. This was an iOS platform change, not something we can work around. The new default mode and quick switcher features are designed to give you equivalent flexibility.
+    Apple removed the ability for third-party keyboards to detect which app is in the foreground. This was an iOS platform change, not something we can work around. You'll need to manually switch between modes when changing tasks.
   </Accordion>
 
   <Accordion title="Why do I have to swipe back to my app after starting dictation?">
@@ -66,10 +40,6 @@ A mode pill on the keyboard lets you temporarily switch to a different mode for 
 
   <Accordion title="Do these changes affect macOS or Windows?">
     No. These are iOS-specific platform changes. The macOS and Windows versions of Superwhisper are unaffected, and features like auto-activation rules continue to work as expected.
-  </Accordion>
-
-  <Accordion title="What languages are supported for the new features?">
-    The default mode and quick mode switcher require English or British English language settings. Support for additional languages is being rolled out gradually.
   </Accordion>
 
   <Accordion title="I'm seeing unexpected behavior beyond what's described here">

--- a/common-issues/ios-26-keyboard-changes.mdx
+++ b/common-issues/ios-26-keyboard-changes.mdx
@@ -9,17 +9,15 @@ This page applies only to Superwhisper on iOS. macOS and Windows are not affecte
 
 ## What Changed
 
-Apple's iOS 26.4 update introduced changes to how third-party keyboards work. Two behaviors that Superwhisper previously relied on are no longer available:
+Apple's iOS 26.4 update introduced changes to how third-party keyboards work. A behavior that Superwhisper previously relied on is no longer available:
 
-1. **No automatic app return** — After tapping the Superwhisper keyboard button to start dictation, iOS no longer returns you to your previous app automatically. You now need to swipe back manually.
-
-2. **No per-app detection** — iOS no longer allows third-party keyboards to detect which app is active. This means Superwhisper can no longer automatically switch modes based on the app you're using.
+- **No automatic app return** — After tapping the Superwhisper keyboard button to start dictation, iOS no longer returns you to your previous app automatically. You now need to swipe back manually.
 
 ---
 
 ## How Superwhisper Adapts
 
-Since per-app detection is no longer available, you'll need to manually switch between modes when moving between tasks. Superwhisper's existing [modes](/modes/modes) — like **Message**, **Email**, **Note**, and any custom modes you've created — all continue to work as before. The only difference is that switching is now always manual.
+All of Superwhisper's existing [modes](/modes/modes) — like **Message**, **Email**, **Note**, and any custom modes you've created — continue to work as before. The only change is the extra swipe back after starting dictation.
 
 <Tip>
 If you haven't already, explore the different [built-in modes](/modes/modes) to find the ones that fit your most common tasks. You can also [create custom modes](/modes/custom) tailored to specific workflows.
@@ -30,10 +28,6 @@ If you haven't already, explore the different [built-in modes](/modes/modes) to 
 ## FAQ
 
 <AccordionGroup>
-  <Accordion title="Why can't Superwhisper switch modes per app anymore?">
-    Apple removed the ability for third-party keyboards to detect which app is in the foreground. This was an iOS platform change, not something we can work around. You'll need to manually switch between modes when changing tasks.
-  </Accordion>
-
   <Accordion title="Why do I have to swipe back to my app after starting dictation?">
     iOS 26.4 no longer allows third-party keyboards to programmatically return you to the previous app. You'll need to swipe back manually after tapping the Superwhisper button.
   </Accordion>
@@ -43,6 +37,10 @@ If you haven't already, explore the different [built-in modes](/modes/modes) to 
   </Accordion>
 
   <Accordion title="I'm seeing unexpected behavior beyond what's described here">
-    If you're experiencing issues not covered above, please contact <a href="mailto:support@superwhisper.com">support@superwhisper.com</a> with your iPhone model and iOS version.
+    If you're experiencing issues not covered above, please contact <a href="mailto:support@superwhisper.com">support@superwhisper.com</a> with your iPhone model, iOS version, and Superwhisper version. A short screen recording of the problem is a huge help too, if you can include one.
+  </Accordion>
+
+  <Accordion title="Can I report this to Apple?">
+    Yes, and we'd encourage it. The more people report the issue, the more likely Apple is to address it. You can file feedback using Apple's [Feedback Assistant](https://feedbackassistant.apple.com/). If you do, consider mentioning the impact on third-party keyboard dictation workflows.
   </Accordion>
 </AccordionGroup>

--- a/common-issues/ios-26-keyboard-changes.mdx
+++ b/common-issues/ios-26-keyboard-changes.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Adapting to iOS 26"
-description: "How iOS 26 changes affect third-party keyboards like Superwhisper, and what we've done to keep your experience smooth."
+title: "Adapting to iOS 26.4"
+description: "How iOS 26.4 changes affect third-party keyboards like Superwhisper, and what we've done to keep your experience smooth."
 ---
 
 <Note>
@@ -9,7 +9,7 @@ This page applies only to Superwhisper on iOS. macOS and Windows are not affecte
 
 ## What Changed
 
-Apple's iOS 26 update introduced changes to how third-party keyboards work. Two behaviors that Superwhisper previously relied on are no longer available:
+Apple's iOS 26.4 update introduced changes to how third-party keyboards work. Two behaviors that Superwhisper previously relied on are no longer available:
 
 1. **No automatic app return** — After tapping the Superwhisper keyboard button to start dictation, iOS no longer returns you to your previous app automatically. You now need to swipe back manually.
 
@@ -61,7 +61,7 @@ A mode pill on the keyboard lets you temporarily switch to a different mode for 
   </Accordion>
 
   <Accordion title="Why do I have to swipe back to my app after starting dictation?">
-    iOS 26 no longer allows third-party keyboards to programmatically return you to the previous app. You'll need to swipe back manually after tapping the Superwhisper button.
+    iOS 26.4 no longer allows third-party keyboards to programmatically return you to the previous app. You'll need to swipe back manually after tapping the Superwhisper button.
   </Accordion>
 
   <Accordion title="Do these changes affect macOS or Windows?">

--- a/docs.json
+++ b/docs.json
@@ -87,6 +87,7 @@
             "group": "Common Issues",
             "pages": [
               "common-issues/troubleshooting",
+              "common-issues/ios-26-keyboard-changes",
               "common-issues/performance-tips",
               "common-issues/appstore",
               "common-issues/realtime",


### PR DESCRIPTION
## Summary
- New docs page covering iOS 26.4 platform changes that affect third-party keyboards
- Explains the two breaking changes: no automatic app return and no per-app detection
- Guides users to manually switch between existing modes
- FAQ section addressing common questions
- Added to Common Issues nav group in docs.json

## Test plan
- [ ] Verify page renders correctly with `mintlify dev`
- [ ] Check internal links to modes and custom modes pages resolve
- [ ] Review FAQ accordion behavior