### PR TITLE
Add/remove some sections in windows feature support

### DIFF
--- a/get-started/windows.mdx
+++ b/get-started/windows.mdx
@@ -18,18 +18,17 @@ We're currently working on bringing the following features to parity with our ma
 Experimental features may be unstable or have limited functionality. By trying them out, you can help us improve Superwhisper for Windows and move toward a stable feature release.
 </Info>
 
-### Models Library
-The models library settings tab is not yet available on Windows.
-
-### Local Language Models
-Local language models that run entirely on your device are not yet supported on Windows. You can still use cloud-based language models for AI processing.
-
 ### Custom App Folder Location
 Changing the [app folder location](/get-started/backing-up-settings#configuration-location) is not yet supported on Windows and is currently a work in progress. The default location (`%LOCALAPPDATA%\com.superwhisper.app`) is used for all configuration, recordings, and modes.
 
-### Autocapitalize Insert
-Automatic capitalization adjustment based on cursor context is not yet supported on Windows and is currently a work in progress.
+### Hold Shift to Auto-Send
+[Hold Shift to Auto-Send](settings-advanced#hold-shift-to-auto-send) is not yet supported on Windows.
 
+### Simulate Keypresses
+[Simulate Keypresses](settings-advanced#simulate-keypresses) is not yet supported on Windows.
+
+### Agentic Coding Integration
+Agentic coding integration with Claude Code, OpenCode, Pi, and Codex is currently in development and not yet available on Windows.
 
 ---
 


### PR DESCRIPTION
- Local model support is now available on windows
- Small features that are still missing: Auto-send and simulate keypresses
- Figured I should include a note about agentic coding