### PR TITLE
docs: document fair-use rate limits on cloud models

### DIFF
--- a/models/language.mdx
+++ b/models/language.mdx
@@ -45,3 +45,24 @@ Ultra-fast inference using Groq's LPU technology. Usage is covered by your licen
 | Name       | Speed | Benchmark (0-100) | Size  | License |
 | ---------- | ----- | ----------------- | ----- | ------- |
 | Llama 3 8b | 10    | 67                | Cloud | Pro     |
+
+## Fair Use & Rate Limits
+
+To keep cloud models fast and available for everyone, Superwhisper applies fair-use rate limits to its hosted cloud models. These are abuse-prevention limits, so normal interactive dictation will not reach them.
+
+Limits apply across all hosted cloud models combined (both language and voice), not per provider:
+
+| Limit     | Threshold              |
+| --------- | ---------------------- |
+| Burst     | 30 requests per minute |
+| Sustained | 300 requests per hour  |
+
+<Note>
+These limits are subject to change as we tune them. If you have a legitimate high-volume use case, [reach out to support](mailto:support@superwhisper.com) or [bring your own API keys](../security/sensitive-data#use-your-own-api-keys-byok) to use your own provider account.
+</Note>
+
+If you exceed a limit, the API returns an `HTTP 429 (Too Many Requests)` response. A `Retry-After` header tells you how many seconds to wait before retrying. Apps built on the Superwhisper API should handle `429` responses gracefully and back off, respecting `Retry-After`.
+
+<Info>
+Bring Your Own Key (BYOK) and local models are not subject to these limits, since requests go through your own account or run on your device.
+</Info>

--- a/models/voice.mdx
+++ b/models/voice.mdx
@@ -51,3 +51,11 @@ The Nova series of models are a Cloud model hosted by Deepgram.
 | Nova 3       | multi | –      | 7     | 8        | Cloud | Pro     |
 | Nova 2       | multi | –      | 7     | 7        | Cloud | Pro     |
 | Nova Medical | en    | –      | 10    | 7        | Cloud | Pro     |
+
+## Fair Use & Rate Limits
+
+Superwhisper's hosted cloud voice models share the same fair-use rate limits as the hosted cloud language models. These are abuse-prevention limits applied across all hosted cloud models combined, so normal interactive dictation will not reach them.
+
+<Note>
+See [Fair Use & Rate Limits](../models/language#fair-use-rate-limits) on the Language Models page for the current thresholds and details.
+</Note>


### PR DESCRIPTION
## What

Documents the new fair-use rate limits applied to Superwhisper's hosted cloud model proxy endpoints (LLM + voice).

- **`models/language.mdx`** — new **Fair Use & Rate Limits** section (canonical home, where most cloud traffic lives). Covers:
  - Limits apply **across all hosted cloud models combined**, not per provider
  - Burst: 30 req/min · Sustained: 300 req/hour
  - `429 (Too Many Requests)` + `Retry-After` behaviour, with guidance to back off
  - BYOK and local models are exempt
- **`models/voice.mdx`** — short cross-reference, since cloud voice models share the same limit.

## Notes

- Placed on the **model pages** rather than the enterprise/org-data API reference. The rate limits cover the app's cloud model endpoints (Anthropic, OpenAI, Groq, Gemini, Grok, ElevenLabs voice, Superwhisper transcribe) — the same models documented on these pages where "usage is covered by your license." The `enterprise/api` section is a separate surface (bearer-token org data API) and isn't affected.
- Framed as forward-looking policy. The numbers live in one editable spot and are explicitly noted as **subject to change**, so the docs stay correct as limits are tuned during rollout.
- Deepgram and the Cerebrium/Modal inference-key endpoints are not rate-limited, so they're left out.
- `mintlify broken-links` flags no issues on the changed pages or the new anchors.